### PR TITLE
Login to GCP when running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
       with:
         service_account_key: ${{ secrets.gcp_service_account }}
         project_id: tensorleap-admin-3
+        export_default_credentials: true
     - name: Configure docker
       run: |-
         gcloud --quiet auth configure-docker
@@ -98,7 +99,7 @@ jobs:
         TAG: ${{ steps.vars.outputs.tag }}
         CMD: ${{ inputs.test_cmd }}
       run: |
-        docker run -e CI=true gcr.io/$GITHUB_REPOSITORY:$TAG $CMD
+        docker run -v $GOOGLE_APPLICATION_CREDENTIALS:$GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_APPLICATION_CREDENTIALS -e CI=true gcr.io/$GITHUB_REPOSITORY:$TAG $CMD
 
   mark-stable:
     needs: [lint, test]


### PR DESCRIPTION
After merging this, `engine` tests will not pass until https://github.com/tensorleap/engine/pull/544 is merged