### PR TITLE
Add artifacts of image diffs on web-ui test fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,28 @@ jobs:
         env:
           TAG: ${{ steps.vars.outputs.tag }}
           CMD: ${{ inputs.test_cmd }}
-          AUTH_SECRET: ${{secrets.gcp_service_account}}
+          AUTH_SECRET: ${{ secrets.gcp_service_account }}
         run: |
-          docker run -v $GOOGLE_APPLICATION_CREDENTIALS:$GOOGLE_APPLICATION_CREDENTIALS -e GOOGLE_APPLICATION_CREDENTIALS -e CI=true -e AUTH_SECRET gcr.io/$GITHUB_REPOSITORY:$TAG $CMD
+          docker run \
+            --name ${{ github.sha }} \
+            -v $GOOGLE_APPLICATION_CREDENTIALS:$GOOGLE_APPLICATION_CREDENTIALS \
+            -e GOOGLE_APPLICATION_CREDENTIALS \
+            -e CI=true \
+            -e AUTH_SECRET \
+            gcr.io/$GITHUB_REPOSITORY:$TAG \
+            $CMD
+      - name: Copy diff image files
+        if: failure()
+        run: |
+          mkdir -p ${{ github.workspace }}/__image_snapshots__/__diff_output__/
+          docker cp ${{ github.sha }}:/app/__image_snapshots__/__diff_output__/ ${{ github.workspace }}/__image_snapshots__/__diff_output__/
+      - name: Upload diff image files
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: diff_output
+          path: ${{ github.workspace }}/__image_snapshots__/__diff_output__/*
+          if-no-files-found: error
 
   mark-stable:
     needs: [lint, test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
+          retention-days: 1
           name: diff_output
           path: ${{ github.workspace }}/__image_snapshots__/__diff_output__/*
           if-no-files-found: error


### PR DESCRIPTION
This PR allows to download the diff images from the CI machine in case of diff errors (so no SSHing into the remote CI machine is needed)